### PR TITLE
Various fixes for BICEP3

### DIFF
--- a/python/auto_setup/main.py
+++ b/python/auto_setup/main.py
@@ -485,7 +485,7 @@ def operate(tuning):
     # Servo control
     tuning.set_exp_param('servo_mode', 3)
     for param in ['servo_p', 'servo_i', 'servo_d', 'flux_jumping',
-                  'data_mode']:
+                  'data_mode', 'pterm_decay_bits']:
         tuning.copy_exp_param('default_%s'%param, param)
 
     # Compile dead detector mask

--- a/python/auto_setup/mux11d.py
+++ b/python/auto_setup/mux11d.py
@@ -178,7 +178,7 @@ def do_rs_servo(tuning, rc, rc_indices):
     optimize = tuning.get_exp_param('optimize_rowsel_servo')
     if optimize == -1:
         # Don't run it, but set the SQ1 bias muxing
-        tuning.set_exp_param("config_fast_sq1_bias", 1)
+        tuning.copy_exp_param("default_config_fast_sq1_bias", "config_fast_sq1_bias", default=1)
         tuning.write_config()
         return
 
@@ -256,8 +256,8 @@ def do_rs_servo(tuning, rc, rc_indices):
     if optimize == 1:
         tuning.set_exp_param('sq1_bias_set', bias_set.transpose().ravel())
 
-    # Enable fast switching.
-    tuning.set_exp_param("config_fast_sq1_bias", 1)
+    # Enable fast switching (if enabled in experiment.cfg)
+    tuning.copy_exp_param("default_config_fast_sq1_bias", "config_fast_sq1_bias", default=1)
 
     tuning.write_config()
     return 0
@@ -328,9 +328,9 @@ def do_sq1_servo_sa(tuning, rc, rc_indices):
     else:
         raise HowDidThisHappen
 
-    # Enable fast switching.
+    # Enable fast switching (if enabled in experiment.cfg)
     tuning.set_exp_param('sq1_bias_set', bias_set.transpose().ravel())
-    tuning.set_exp_param("config_fast_sq1_bias", 1)
+    tuning.copy_exp_param("default_config_fast_sq1_bias", "config_fast_sq1_bias", default=1)
     super_servo = tuning.get_exp_param('config_mux11d_all_rows')
     fb_set = tuning.get_exp_param('sa_fb_set').reshape(-1, nr).\
         transpose() # r,c

--- a/python/auto_setup/sq1_servo.py
+++ b/python/auto_setup/sq1_servo.py
@@ -288,6 +288,9 @@ class SQ1Servo(servo.SquidData):
         if slope is None:
             # Dodge possiblity that params are different lengths...
             s1 = self.tuning.get_exp_param('default_servo_i')[self.cols]
+            # Use P gain if I gain is zero and 1 if both are, to avoid a zero slope
+            s1[s1 == 0] = self.tuning.get_exp_param('default_servo_p')[self.cols][s1 == 0]
+            s1[s1 == 0] = 1
             s2 = self.tuning.get_exp_param('sq1_servo_gain')[self.cols]
             slope = -sign(s1*s2)
         if not hasattr(slope, '__getitem__'):
@@ -557,6 +560,9 @@ class SQ1ServoSA(SQ1Servo):
         if slope is None:
             # Dodge possiblity that params are different lengths...
             s1 = self.tuning.get_exp_param('default_servo_i')[self.cols]
+            # Use P gain if I gain is zero and 1 if both are, to avoid a zero slope
+            s1[s1 == 0] = self.tuning.get_exp_param('default_servo_p')[self.cols][s1 == 0]
+            s1[s1 == 0] = 1
             s2 = self.tuning.get_exp_param('sq1_servo_gain')[self.cols]
             slope = -sign(s1*s2)
         if not hasattr(slope, '__getitem__'):

--- a/python/auto_setup/util/tuning.py
+++ b/python/auto_setup/util/tuning.py
@@ -84,11 +84,11 @@ class tuningData:
     def clear_exp_param(self, key):
         return self.set_exp_param(key, 0*self.get_exp_param(key))
 
-    def copy_exp_param(self, src_key, dest_key):
+    def copy_exp_param(self, src_key, dest_key, missing_ok=False, default=None):
         """
         Copy the value in src_key to dest_key.
         """
-        return self.set_exp_param(dest_key, self.get_exp_param(src_key))
+        return self.set_exp_param(dest_key, self.get_exp_param(src_key, missing_ok=missing_ok, default=default))
 
     def run(self, args, no_log=False):
         if (no_log):

--- a/python/mce_control.py
+++ b/python/mce_control.py
@@ -175,8 +175,8 @@ class mce_control(MCE):
     def servo_mode(self, mode=None):
         if mode is not None:
             # Broadcast to all columns
-            mode = [mode] * MCE_CHANS
-        return self.io_rc_sync('servo_mode', mode)
+            mode = [mode] * (self.n_chan * self.n_rc)
+        return self.io_readwrite('sq1', 'servo_mode', mode)
 
     def gaini(self, gains=None):
         return self.io_rc_array_2d('gaini%i', gains)

--- a/script/bits/config_create.bash
+++ b/script/bits/config_create.bash
@@ -110,6 +110,11 @@ vals=${sq2_bias[@]}
 mask=${columns_off[@]}
 sq2_bias=( `mask_values "$vals" "$mask" 1 0` )
 
+# Insist that fb_const=-8192 (0V) for bad columns.
+vals="`repeat_string $fb_const 32`"
+mask=${columns_off[@]}
+fb_const=( `mask_values "$vals" "$mask" 1 -8192` )
+
 for rc in 1 2 3 4; do
     min_flux_quantum=999999
     max_gaini=0
@@ -124,7 +129,7 @@ for rc in 1 2 3 4; do
     echo "wb rc$rc sample_dly   $sample_dly" >> $mce_script
     echo "wb rc$rc sample_num   $sample_num" >> $mce_script
     echo "wb rc$rc fb_dly       $fb_dly" >> $mce_script
-    echo "wb rc$rc fb_const    " `repeat_string $fb_const 8` >> $mce_script
+    echo "wb rc$rc fb_const     ${fb_const[@]:$ch_ofs:8}" >> $mce_script
     echo "wb rc$rc data_mode    $data_mode" >> $mce_script
     echo "wb rc$rc sa_bias      ${sa_bias[@]:$ch_ofs:8}" >> $mce_script
     echo "wb rc$rc offset       ${sa_offset[@]:$ch_ofs:8}" >> $mce_script

--- a/script/mce_configure
+++ b/script/mce_configure
@@ -196,6 +196,9 @@ adc_offset = np.ones((AROW,1), int) * cfg['adc_offset_c'] / cfg['sample_num']
 if cfg['config_adc_offset_all']:
     adc_offset = cfg_2d('adc_offset_cr')
 
+# Duplicated scalar for enabled cols; -8192 (0V) for bad cols
+fb_const = columns_on * cfg['fb_const'] + ~columns_on * -8192
+
 rc_select = (cfg['hardware_rc']!=0)*(cfg['config_rc']!=0)
 for rc_i in rc_select.nonzero()[0]:
     rc = 'rc%i' % (rc_i+1)  # Yes, rc_i=0 -> 'rc1'.
@@ -218,7 +221,7 @@ for rc_i in rc_select.nonzero()[0]:
     W(rc, 'sample_dly', cfg['sample_dly'])
     W(rc, 'sample_num', cfg['sample_num'])
     W(rc, 'fb_dly', cfg['fb_dly'])
-    W(rc, 'fb_const', [cfg['fb_const']]*COLS_PER_RC)  # scalar, duplicated
+    W(rc, 'fb_const', fb_const[col_start:col_end])
     W(rc, 'data_mode', cfg['data_mode'])
     W(rc, 'sa_bias', cfg['sa_bias'][col_start:col_end])
     W(rc, 'offset', cfg['sa_offset'][col_start:col_end])

--- a/template/experiment.cfg
+++ b/template/experiment.cfg
@@ -405,6 +405,8 @@ config_fast_sq2 = 0;
 ## Mux11d support
 config_fast_sq1_bias = 0;
 config_fast_sa_fb = 0;
+# Set these to 0 to turn off fast switching
+default_config_fast_sq1_bias = 1;
 
 ## When config_dead_tes is 0, the dead_detectors mask will be
 ## used to set PID parameters to zero for all dead detectors.

--- a/template/experiment.cfg
+++ b/template/experiment.cfg
@@ -407,6 +407,7 @@ config_fast_sq1_bias = 0;
 config_fast_sa_fb = 0;
 # Set these to 0 to turn off fast switching
 default_config_fast_sq1_bias = 1;
+default_config_fast_sa_fb = 1;
 
 ## When config_dead_tes is 0, the dead_detectors mask will be
 ## used to set PID parameters to zero for all dead detectors.


### PR DESCRIPTION
This PR is meant to upstream various changes that have been made locally for operating BICEP3's MCEs.

The most generally applicable change is to set `fb_const` to 0V for columns that are turned off, instead of the mid-point of the DAC range. This can be useful for preventing focal plane heating issues when there are shorts present.

Other changes are to honor the `pterm_decay_bits` setting, to allow SQ1 bias and SA feedback fast switching to be turned off, and to avoid divide by zero in SQ1 servo SA tuning when the `I` gain is zero.